### PR TITLE
Fix using cached variables

### DIFF
--- a/expected/pg_variables_trans.out
+++ b/expected/pg_variables_trans.out
@@ -1838,3 +1838,19 @@ SELECT pgv_remove('vars');
  
 (1 row)
 
+-- REMOVED TRANSACTIONAL VARIABLE SHOULD BE NOT ACCESSIBLE THROUGH LastVariable
+SELECT pgv_insert('package', 'errs',row(n), true)
+FROM generate_series(1,5) AS gs(n) WHERE 1.0/(n-3)<>0;
+ERROR:  division by zero
+SELECT pgv_insert('package', 'errs',row(1), true);
+ pgv_insert 
+------------
+ 
+(1 row)
+
+SELECT pgv_free();
+ pgv_free 
+----------
+ 
+(1 row)
+

--- a/pg_variables.c
+++ b/pg_variables.c
@@ -1632,6 +1632,9 @@ removeObject(TransObject *object, TransObjectType type)
 
 	/* Remove object from hash table */
 	hash_search(hash, object->name, HASH_REMOVE, &found);
+
+	LastPackage = NULL;
+	LastVariable = NULL;
 }
 
 /*

--- a/sql/pg_variables_trans.sql
+++ b/sql/pg_variables_trans.sql
@@ -460,3 +460,10 @@ SELECT pgv_set('vars', 'trans1', 'package restored'::text, true);
 SELECT * FROM pgv_list() ORDER BY package, name;
 COMMIT;
 SELECT pgv_remove('vars');
+
+-- REMOVED TRANSACTIONAL VARIABLE SHOULD BE NOT ACCESSIBLE THROUGH LastVariable
+SELECT pgv_insert('package', 'errs',row(n), true)
+FROM generate_series(1,5) AS gs(n) WHERE 1.0/(n-3)<>0;
+SELECT pgv_insert('package', 'errs',row(1), true);
+
+SELECT pgv_free();


### PR DESCRIPTION
Добавлено очищение кэша переменных полсе удаления любого объекта.
Возможно имеет смысл проверять, что лежит в кэше и сравнивать с удаляемым объектом и не очищать кэш, если там лежит что-то другое.