### PR TITLE
Reset the Package->hctxRegular field

### DIFF
--- a/expected/pg_variables_trans.out
+++ b/expected/pg_variables_trans.out
@@ -1705,6 +1705,12 @@ SELECT pgv_free();
  
 (1 row)
 
+SELECT pgv_free(); -- Check sequential package removal in one subtransaction
+ pgv_free 
+----------
+ 
+(1 row)
+
 SELECT * FROM pgv_list() ORDER BY package, name;
  package | name | is_transactional 
 ---------+------+------------------

--- a/pg_variables.c
+++ b/pg_variables.c
@@ -916,7 +916,11 @@ removePackageInternal(Package *package)
 	TransObject *transObject;
 
 	/* All regular variables will be freed */
-	MemoryContextDelete(package->hctxRegular);
+	if (package->hctxRegular)
+	{
+		MemoryContextDelete(package->hctxRegular);
+		package->hctxRegular = NULL;
+	}
 
 	/* Add to changes list */
 	transObject = &package->transObject;

--- a/sql/pg_variables_trans.sql
+++ b/sql/pg_variables_trans.sql
@@ -425,6 +425,7 @@ SELECT pgv_set('vars', 'regular', 'regular variable exists'::text);
 SELECT pgv_set('vars', 'trans1', 'trans1 variable exists'::text, true);
 BEGIN;
 SELECT pgv_free();
+SELECT pgv_free(); -- Check sequential package removal in one subtransaction
 SELECT * FROM pgv_list() ORDER BY package, name;
 SELECT pgv_set('vars', 'trans2', 'trans2 variable exists'::text, true);
 SELECT * FROM pgv_list() ORDER BY package, name;


### PR DESCRIPTION
В случае, когда пакет удаляется, ещё перед завершением транзакции мы смело можем удалять все обычные (не транзакционные) переменные. Для этого мы удаляем MemoryContext, в котором они хранятся. Далее, в случае коммита, удаляются остальные данные Package, а в случае роллбэка - создаётся новый контекст памяти и HTAB под обычные переменные.
В случае, если в одной транзакции был вызван pgv_free() 2 раза подряд, то бэкенд пытается удалить уже удалённый контекст - что завершается ошибкой.
Этот патч это исправляет.