### PR TITLE
Delete a variable if an error occurs during its creation

### DIFF
--- a/expected/pg_variables_trans.out
+++ b/expected/pg_variables_trans.out
@@ -1854,6 +1854,11 @@ SELECT pgv_insert('package', 'errs',row(1), true);
  
 (1 row)
 
+-- Variable should not exists in case when error occurs during creation
+SELECT pgv_insert('vars4', 'r1', row('str1', 'str1'));
+ERROR:  could not identify a hash function for type unknown
+SELECT pgv_select('vars4', 'r1', 0);
+ERROR:  unrecognized variable "r1"
 SELECT pgv_free();
  pgv_free 
 ----------

--- a/pg_variables.h
+++ b/pg_variables.h
@@ -155,6 +155,7 @@ extern void check_record_key(Variable *variable, Oid typid);
 extern void insert_record(Variable *variable, HeapTupleHeader tupleHeader);
 extern bool update_record(Variable *variable, HeapTupleHeader tupleHeader);
 extern bool delete_record(Variable *variable, Datum value, bool is_null);
+extern void removeObject(TransObject *object, TransObjectType type);
 
 #define GetActualState(object) \
 	(dlist_head_element(TransState, node, &((TransObject *) object)->states))

--- a/sql/pg_variables_trans.sql
+++ b/sql/pg_variables_trans.sql
@@ -467,4 +467,8 @@ SELECT pgv_insert('package', 'errs',row(n), true)
 FROM generate_series(1,5) AS gs(n) WHERE 1.0/(n-3)<>0;
 SELECT pgv_insert('package', 'errs',row(1), true);
 
+-- Variable should not exists in case when error occurs during creation
+SELECT pgv_insert('vars4', 'r1', row('str1', 'str1'));
+SELECT pgv_select('vars4', 'r1', 0);
+
 SELECT pgv_free();


### PR DESCRIPTION
В случае, если при создания переменной типа record возникала ошибка в функции init_record, переменная оставась созданной и выдавала ошибку при обращении к ней