### PR TITLE
Package optimizing

### DIFF
--- a/expected/pg_variables_trans.out
+++ b/expected/pg_variables_trans.out
@@ -1879,7 +1879,7 @@ SELECT pgv_remove('vars', 'any1');
 
 RELEASE comm;
 SELECT pgv_get('vars', 'any1',NULL::text);
-ERROR:  unrecognized variable "any1"
+ERROR:  unrecognized package "vars"
 COMMIT;
 -- Tests for PGPRO-2440
 SELECT pgv_insert('vars3', 'r3', row(1 :: integer, NULL::varchar), true);

--- a/expected/pg_variables_trans.out
+++ b/expected/pg_variables_trans.out
@@ -1935,6 +1935,33 @@ ERROR:  syntax error at or near "ERROR"
 LINE 1: ERROR;
         ^
 COMMIT;
+BEGIN;
+SELECT pgv_set('vars', 'any1', 'some value'::text, true);
+ pgv_set 
+---------
+ 
+(1 row)
+
+SELECT pgv_free();
+ pgv_free 
+----------
+ 
+(1 row)
+
+SAVEPOINT sp_to_rollback;
+SELECT pgv_set('vars', 'any1', 'some value'::text, true);
+ pgv_set 
+---------
+ 
+(1 row)
+
+ROLLBACK TO sp_to_rollback;
+COMMIT;
+SELECT package FROM pgv_stats() ORDER BY package;
+ package 
+---------
+(0 rows)
+
 SELECT pgv_free();
  pgv_free 
 ----------

--- a/pg_variables.c
+++ b/pg_variables.c
@@ -1605,6 +1605,10 @@ createVariableInternal(Package *package, text *name, Oid typid, bool is_record,
 		}
 	}
 
+	/*
+	 * If the variable has been created or has just become valid,
+	 * increment the counter of valid transactional variables.
+	 */
 	if (is_transactional &&
 		(!found || !GetActualState(variable)->is_valid))
 		GetPackState(package)->trans_var_num++;

--- a/pg_variables.c
+++ b/pg_variables.c
@@ -899,8 +899,8 @@ remove_variable(PG_FUNCTION_ARGS)
 			addToChangesStack(transObject, TRANS_VARIABLE);
 		}
 		GetActualState(variable)->is_valid = false;
-		numOfTransVars(package)--;
-		if ((numOfTransVars(package) + numOfRegVars(package)) == 0)
+		GetPackState(package)->trans_var_num--;
+		if ((GetPackState(package)->trans_var_num + numOfRegVars(package)) == 0)
 			GetActualState(package)->is_valid = false;
 	}
 	else
@@ -962,7 +962,7 @@ removePackageInternal(Package *package)
 		addToChangesStack(transObject, TRANS_PACKAGE);
 	}
 	GetActualState(package)->is_valid = false;
-	numOfTransVars(package) = 0;
+	GetPackState(package)->trans_var_num = 0;
 }
 
 static bool
@@ -1384,7 +1384,8 @@ getPackage(text *name, bool strict)
 
 		if (found && GetActualState(package)->is_valid)
 		{
-			Assert (numOfTransVars(package) + numOfRegVars(package) > 0);
+			Assert (GetPackState(package)->trans_var_num +
+					numOfRegVars(package) > 0);
 			return package;
 		}
 	}
@@ -1610,7 +1611,7 @@ createVariableInternal(Package *package, text *name, Oid typid, bool is_record,
 
 	if (is_transactional &&
 		(!found || !GetActualState(variable)->is_valid))
-		numOfTransVars(package)++;
+		GetPackState(package)->trans_var_num++;
 	GetActualState(variable)->is_valid = true;
 	
 	Assert (numOfTransVars(package) == _numOfTransVars(package));

--- a/pg_variables.c
+++ b/pg_variables.c
@@ -1408,19 +1408,17 @@ createPackage(text *name, bool is_trans)
 
 	if (found)
 	{
+		TransObject *transObj = &package->transObject;
+
+		if (!isObjectChangedInCurrentTrans(transObj))
+			createSavepoint(transObj, TRANS_PACKAGE);
+
 		if (!GetActualState(package)->is_valid)
-		/* Make package valid again */
 		{
 			HASH_SEQ_STATUS vstat;
 			Variable   *variable;
-			TransObject *transObj = &package->transObject;
-
-			/* Make new history entry of package */
-			if (!isObjectChangedInCurrentTrans(transObj))
-				createSavepoint(transObj, TRANS_PACKAGE);
 
 			GetActualState(package)->is_valid = true;
-
 			/* Mark all transactional variables in package as removed */
 			if (package->varHashTransact)
 			{
@@ -1448,14 +1446,14 @@ createPackage(text *name, bool is_trans)
 		package->hctxRegular = NULL;
 		package->hctxTransact = NULL;
 		initObjectHistory(&package->transObject, TRANS_PACKAGE);
-		/* Add to changes list */
-		if (!isObjectChangedInCurrentTrans(&package->transObject))
-			addToChangesStack(&package->transObject, TRANS_PACKAGE);
 	}
 
 	/* Create corresponding HTAB if not exists */
 	if (!pack_htab(package, is_trans))
 		makePackHTAB(package, is_trans);
+	/* Add to changes list */
+	if (!isObjectChangedInCurrentTrans(&package->transObject))
+		addToChangesStack(&package->transObject, TRANS_PACKAGE);
 
 	return package;
 }

--- a/pg_variables.h
+++ b/pg_variables.h
@@ -171,15 +171,11 @@ extern void removeObject(TransObject *object, TransObjectType type);
 #define GetActualValue(variable) \
 	(((VarState *) GetActualState(variable))->value)
 
-#define numOfTransVars(package) \
-	(((PackState *) GetActualState(package))->trans_var_num)
+#define GetPackState(package) \
+	(((PackState *) GetActualState(package)))
 
 #define GetName(object) \
 	(AssertVariableIsOfTypeMacro(object->transObject, TransObject), \
 	 object->transObject.name)
-
-#define GetStateStorage(object) \
-	(AssertVariableIsOfTypeMacro(object->transObject, TransObject), \
-	 &(object->transObject.states))
 
 #endif							/* __PG_VARIABLES_H__ */

--- a/pg_variables.h
+++ b/pg_variables.h
@@ -63,7 +63,8 @@ typedef struct TransState
 /* List node that stores one of the package's states */
 typedef struct PackState
 {
-	TransState	state;
+	TransState		state;
+	unsigned long	trans_var_num; /* Number of valid transactional variables */
 }			PackState;
 
 /* List node that stores one of the variable's states */
@@ -169,6 +170,9 @@ extern void removeObject(TransObject *object, TransObjectType type);
 
 #define GetActualValue(variable) \
 	(((VarState *) GetActualState(variable))->value)
+
+#define numOfTransVars(package) \
+	(((PackState *) GetActualState(package))->trans_var_num)
 
 #define GetName(object) \
 	(AssertVariableIsOfTypeMacro(object->transObject, TransObject), \

--- a/sql/pg_variables_trans.sql
+++ b/sql/pg_variables_trans.sql
@@ -500,4 +500,13 @@ SELECT pgv_free();
 ERROR;
 COMMIT;
 
+BEGIN;
+SELECT pgv_set('vars', 'any1', 'some value'::text, true);
+SELECT pgv_free();
+SAVEPOINT sp_to_rollback;
+SELECT pgv_set('vars', 'any1', 'some value'::text, true);
+ROLLBACK TO sp_to_rollback;
+COMMIT;
+SELECT package FROM pgv_stats() ORDER BY package;
+
 SELECT pgv_free();


### PR DESCRIPTION
Оптимизация создания и удаления пакетов.
Теперь в пакете создаются только те HTAB-ы, которые нужны для хранения переменных. Например, если в пакете лежат только транзакционные переменные, то package->varHashRegular создаваться не будет. 
Также теперь транзакционные объекты удаляются на один уровень выше. Это сделано для того, чтобы не выполнять лишний поиск по спискам changedVarsList и changedPacksList для удаления элемента. Например:
`BEGIN;
SELECT pgv_set('vars', 'any1', 'some value'::text, true);
SAVEPOINT comm;
SELECT pgv_remove('vars', 'any1');
RELEASE comm;
-- Тут ещё vars и any1 лежат в памяти, но отмечены как state->valid=false;
COMMIT; 
-- Тут оба объекта уже удалены из памяти.
`