### PR TITLE
Clear LastHSeqStatus when subtransaction ends

### DIFF
--- a/pg_variables.c
+++ b/pg_variables.c
@@ -2124,6 +2124,7 @@ pgvSubTransCallback(SubXactEvent event, SubTransactionId mySubid,
 				break;
 		}
 	}
+	LastHSeqStatus = NULL;
 }
 
 /*
@@ -2152,10 +2153,7 @@ pgvTransCallback(XactEvent event, void *arg)
 				break;
 		}
 	}
-
-	if (event == XACT_EVENT_PARALLEL_ABORT || event == XACT_EVENT_ABORT)
-		if (LastHSeqStatus)
-			LastHSeqStatus = NULL;
+	LastHSeqStatus = NULL;
 }
 
 /*


### PR DESCRIPTION
Переменную LastHSeqStatus нужно обнулять при откате как основной транзакции, так и субтранзакции: если внутри вложенной транзакции произойдёт ошибка и контекст памяти funcctx->multi_call_memory_ctx затрётся - то мы сегфолтнемся при обращении к содержимому LastHSeqStatus.
Обнулять LastHSeqStatus безопасно без каких-либо условий, потому что в конце транзакции мы обычно уже заканчиваем последовательный проход по хэш-таблице, либо контекст памяти со статусом прохода по хэш-таблице затрётся сам.